### PR TITLE
Refactor CycleConfig to use milliseconds and JSON

### DIFF
--- a/backend/cycle_config.py
+++ b/backend/cycle_config.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field
 from typing import List
 import json
-from cycle_action import CycleAction
+from backround.cycle_action import CycleAction, ActionType
 
 @dataclass
 class CycleConfig:


### PR DESCRIPTION
I modified my original cycle_config.py file (using Felicity's suggestions) to read from JSON files as well as to use a list of CycleAction instances (cycle_actions.py) instead of SoundConfig instances (sound_config.py) directly. Let me know if it looks good or if I should make any changes.