### PR TITLE
updated homepage and group mapping

### DIFF
--- a/frontend/create_cycle_widgets/cc_sound_group_mapping_widgets/cc_sound_group_mapping.py
+++ b/frontend/create_cycle_widgets/cc_sound_group_mapping_widgets/cc_sound_group_mapping.py
@@ -39,6 +39,7 @@ def get_dynamic_group_options(controller):
 
 SOUND_DROPDOWN_PLACEHOLDER = "SOUNDS"
 MAX_SOUNDS_PER_GROUP = 3
+SAMPLE_PLAYBACK_SECONDS = 5
 
 
 class FixedComboBox(QComboBox):
@@ -745,8 +746,8 @@ class CCSoundGroupMappingPage(QWidget):
             print(f"[play_sample_pressed] Error calling play_group_sample: {exc}")
             return
 
-        # Use a fixed 10 second sample duration for UI lockout
-        max_duration = 10
+        # Use a fixed 5 second sample duration for UI lockout
+        max_duration = SAMPLE_PLAYBACK_SECONDS
         self.SAMPLE_PLAYBACK_ACTIVE = True
 
         # Grey out dropdowns and show countdown as placeholder

--- a/frontend/home_page_widgets/cycle_selector_widget.py
+++ b/frontend/home_page_widgets/cycle_selector_widget.py
@@ -13,7 +13,10 @@ from PySide6.QtGui import QFont, QMouseEvent, QPainter
 from frontend.home_page_widgets.custom_cycle_button import CustomCycleButton
 
 CYCLE_OPTIONS_DROPDOWN_COLOUR = "#FAF5F5"
+SCROLL_BACKGROUND_COLOUR = "#F1F1EE"
 DROPDOWN_BUTTON_GAP_PX = 20
+DROP_DOWN_ROW_EXTRA_PX = 4
+DROP_DOWN_ITEM_PADDING_Y_PX = 8
 DELETE_ICON_ROLE = Qt.UserRole + 1
 
 
@@ -51,7 +54,7 @@ class FixedComboBox(QComboBox):
         Initialize combo box with touch-friendly scrolling behavior.
         """
         super().__init__(parent)
-        self.popup_max_visible_items = 3
+        self.popup_max_visible_items = 2
         view = self.view()
         view.setVerticalScrollMode(QAbstractItemView.ScrollPerPixel)
         QScroller.grabGesture(view.viewport(), QScroller.LeftMouseButtonGesture)
@@ -72,16 +75,20 @@ class FixedComboBox(QComboBox):
         view.setFrameShape(QFrame.NoFrame)
         view.setStyleSheet("""
             QListView {
-                background: #FAF5F5;
+                background: #F1F1EE;
                 border: none;
                 color: black;
-                padding: 4px;
+                padding: 6px;
                 outline: 0;
                 selection-background-color: #d9d9d9;
                 selection-color: black;
             }
+            QListView::item {
+                min-height: 48px;
+                padding: 8px 12px;
+            }
             QScrollBar:vertical {
-                background:  #FAF5F5;
+                background: #F1F1EE;
                 width: 14px;
                 margin: 8px 2px 8px 0;
                 border-radius: 7px;
@@ -92,22 +99,24 @@ class FixedComboBox(QComboBox):
                 border-radius: 7px;
             }
             QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
-                background: #FAF5F5;
+                background: #F1F1EE;
                 height: 0px;
             }
             QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
-                background:  #FAF5F5;
+                background: #F1F1EE;
             }
         """)
 
         row_height = view.sizeHintForRow(0)
         if row_height <= 0:
             row_height = 28
-        visible_rows = max(1, min(self.count(), max_visible_items))
+        row_height += DROP_DOWN_ROW_EXTRA_PX + DROP_DOWN_ITEM_PADDING_Y_PX
+        visible_rows = min(self.count(), 2.25) if self.count() > 2 else self.count()
+        visible_rows = max(1, visible_rows)
 
         # Content size for the inner view.
         content_width = self.width()
-        content_height = (row_height * visible_rows) + 8
+        content_height = int((row_height * visible_rows) + 8)
 
         view.setMinimumWidth(content_width)
         view.setMaximumWidth(content_width)
@@ -123,7 +132,7 @@ class FixedComboBox(QComboBox):
 
             popup.setStyleSheet("""
                 QFrame {
-                    background: white;
+                    background: #F1F1EE;
                     border: 1px solid #0474BA;
                     border-radius: 14px;
                 }
@@ -181,7 +190,8 @@ class CycleSelectorWidget(QWidget):
             }}
             QComboBox QAbstractItemView {{
                 color: black;
-                background: white;
+                background: {SCROLL_BACKGROUND_COLOUR};
+                alternate-background-color: {SCROLL_BACKGROUND_COLOUR};
                 selection-color: black;
                 selection-background-color: #d9d9d9;
             }}

--- a/frontend/home_page_widgets/home_page.py
+++ b/frontend/home_page_widgets/home_page.py
@@ -39,7 +39,7 @@ class HomePage(QWidget):
         self.light_controller = light_controller
         self.sound_controller = sound_controller
         self.main_layout = QGridLayout()
-        self.main_layout.setContentsMargins(40, 110, 40, 40)
+        self.main_layout.setContentsMargins(40, 20, 40, 40)
         self.cur_cycle_id = None
         self.pending_delete_cycle_id = None
         self.background_path = "resources/home_page_assets/home_page_background.png"

--- a/frontend/home_page_widgets/play_square_widget.py
+++ b/frontend/home_page_widgets/play_square_widget.py
@@ -15,6 +15,8 @@ from PySide6.QtCore import (
 ) 
 from frontend.helpers import make_button_circle
 
+PLAY_BUTTON_SIZE = 120
+
 class PlaySquareWidget(QWidget):
     def __init__(self, parent=None):
         """
@@ -29,7 +31,7 @@ class PlaySquareWidget(QWidget):
         main_layout = QGridLayout()
         main_layout.setContentsMargins(0, 0, 0, 0)
         main_layout.setSpacing(0)
-        self.setFixedSize(353,273)
+        self.setFixedSize(353,244)
 
         ## this has the current cycle id, gets updated from CyclePlayerWidget
         self.cur_cycle_id = None
@@ -51,13 +53,18 @@ class PlaySquareWidget(QWidget):
 
         # Keep icon/button on top of the blue box so transparent pixels show blue, not page white.
         blue_box_layout = QGridLayout(blue_box)
-        blue_box_layout.setContentsMargins(12, 6, 12, 12)
+        blue_box_layout.setContentsMargins(10, 4, 10, 8)
         blue_box_layout.setSpacing(0)
         
         #for the actual play button to press the cycle
-        cycle_play_button_pix = QPixmap(play_button_asset_path)
+        cycle_play_button_pix = QPixmap(play_button_asset_path).scaled(
+            PLAY_BUTTON_SIZE,
+            PLAY_BUTTON_SIZE,
+            Qt.KeepAspectRatio,
+            Qt.SmoothTransformation,
+        )
         cycle_play_button = QPushButton()
-        cycle_play_button_size = cycle_play_button_pix.width()
+        cycle_play_button_size = PLAY_BUTTON_SIZE
 
         cycle_play_button.setFixedSize(cycle_play_button_size,cycle_play_button_size)
         cycle_play_button.setIcon(QIcon(cycle_play_button_pix))


### PR DESCRIPTION
updated the homepage so that the cycle selector is more spaced out. I also shortened the blue play cycle square and reduce the space at the top to allow for more room for the drop down.

also adjust the length of time the sample plays for in create cycle-sound mapping